### PR TITLE
Fix geomstats dependency

### DIFF
--- a/tutorial/NeuroSEED.ipynb
+++ b/tutorial/NeuroSEED.ipynb
@@ -122,7 +122,7 @@
     "id": "FwCBrVVic4Xp"
    },
    "source": [
-    "!pip3 install geomstats\n",
+    "!pip3 install geomstats==2.2\n",
     "!apt install clustalw\n",
     "!pip install biopython\n",
     "!pip install python-Levenshtein\n",


### PR DESCRIPTION
Tutorial notebook no longer works without specifying geomstats version. Maintainer should also update geomstats import in colab.